### PR TITLE
Update ample_post_card.dart

### DIFF
--- a/lib/projects/instagram_redesign/ui/widgets/ample_post_card.dart
+++ b/lib/projects/instagram_redesign/ui/widgets/ample_post_card.dart
@@ -90,7 +90,7 @@ class AmplePostCardState extends State<AmplePostCard>
               //------PAGE VIEW IMAGES POST
               //-------------------------------------
               ClipRRect(
-                borderRadius: widget.borderRadius as BorderRadius?,
+                borderRadius: widget.borderRadius ?? BorderRadius.zero,
                 child: PageView.builder(
                   onPageChanged: (value) => _indexNotifier.value = value,
                   itemCount: post.photos!.length,
@@ -107,7 +107,7 @@ class AmplePostCardState extends State<AmplePostCard>
                             imageUrl: post.photos![index],
                             fit: BoxFit.cover,
                             placeholder: (context, url) =>
-                                const CupertinoActivityIndicator(radius: 40),
+                            const CupertinoActivityIndicator(radius: 40),
                           ),
                         ),
                         //-----------------------
@@ -133,6 +133,7 @@ class AmplePostCardState extends State<AmplePostCard>
                   },
                 ),
               ),
+
               //------------------------------------
               //---USER PHOTO AND PAGE INDICATORS
               //------------------------------------


### PR DESCRIPTION
This pull request addresses errors caused by deprecated named parameters in the TextTheme and ThemeData classes in Flutter. The parameters have been updated to their new names as per the latest Flutter guidelines.

Changes Made :

1. Updated TextTheme Parameters:

headline1 -> displayLarge
headline2 -> displayMedium
headline3 -> displaySmall
headline4 -> headlineLarge
headline5 -> headlineMedium
headline6 -> headlineSmall
subtitle1 -> titleMedium
subtitle2 -> titleSmall
bodyText1 -> bodyLarge
bodyText2 -> bodyMedium
caption -> bodySmall
button -> labelLarge
overline -> labelSmall
Updated ThemeData Parameters:

2. Replaced backgroundColor with scaffoldBackgroundColor or colorScheme.background.